### PR TITLE
Timeout: customize request/confirm timeout

### DIFF
--- a/lib/wpc/include/wpc_internal.h
+++ b/lib/wpc/include/wpc_internal.h
@@ -18,7 +18,7 @@
 typedef void (*onIndicationReceivedLocked_cb_f)(wpc_frame_t * frame,
                                                 unsigned long long timestamp_ms);
 /**
- * \brief   Function to send a request
+ * \brief   Function to send a request and wait for confirm for default timeout
  * \param   frame
  *          The request to send
  * \param   confirm
@@ -26,11 +26,27 @@ typedef void (*onIndicationReceivedLocked_cb_f)(wpc_frame_t * frame,
  * \return  0 if successful or negative value if an error happen
  *
  * \note    This method can be called from different context at the same time
- *          or before the last is acknowledged from the stack. Thus, the calling
- *          thread can be locked
+ *          thus, the calling thread can be locked
  */
 int WPC_Int_send_request(wpc_frame_t *frame,
                          wpc_frame_t *confirm);
+
+/**
+ * \brief   Function to send a request and wait for confirm for given timeout
+ * \param   frame
+ *          The request to send
+ * \param   confirm
+ *          The confirm received by the stack
+ * \param   timeout_ms
+ *          Timeout to wait for confirm in ms
+ * \return  0 if successful or negative value if an error happen
+ *
+ * \note    This method can be called from different context at the same time
+ *          thus, the calling thread can be locked
+ */
+int WPC_Int_send_request_timeout(wpc_frame_t *frame,
+                                 wpc_frame_t *confirm,
+                                 uint16_t timeout_ms);
 
 /**
  * \brief   Function to retrieved indication

--- a/lib/wpc/msap.c
+++ b/lib/wpc/msap.c
@@ -222,8 +222,11 @@ int msap_scratchpad_start_request(uint32_t length,
     request.payload.msap_image_start_request_payload.scratchpad_sequence_number = seq;
     request.payload_length = sizeof(msap_image_start_req_pl_t);
 
-    res = WPC_Int_send_request(&request,
-                               &confirm);
+    // Starting a scrtachpad may trigger an erase of scratchpad area so can be quite long operartion
+    // and confirm can be delayed for quite a long time. So set tiemout to high value (up to 5 sec).
+    res = WPC_Int_send_request_timeout(&request,
+                                       &confirm,
+                                       5000);
 
     if (res < 0)
         return res;


### PR DESCRIPTION
Some confirms can be delayed for long time like a start scratchpad
because the scratchpad is erased before confirm is sent.
This patch adds a way to not use the defaut value in some case that is 500ms.
Scratchpad start has now a timeout of 5 sec