### PR TITLE
Otap: better handle otap exchange with neighbors

### DIFF
--- a/lib/platform/linux/platform.c
+++ b/lib/platform/linux/platform.c
@@ -214,9 +214,9 @@ static void * poll_for_indication(void * unused)
         }
 
 #if MAX_DURATION_POLL_FAIL_S != 0
-        if (get_ind_res >= 0)
+        if (get_ind_res >= 0 || get_ind_res == WPC_INT_SYNC_ERROR)
         {
-            // Poll request executed fine, reset fail counter
+            // Poll request executed fine or at least com is working with sink, reset fail counter
             m_last_successful_poll_ts = get_timestamp_s();
         }
         else

--- a/lib/platform/linux/serial.c
+++ b/lib/platform/linux/serial.c
@@ -16,7 +16,7 @@
 #include "serial_termios2.h"
 
 #define LOG_MODULE_NAME "SERIAL"
-#define MAX_LOG_LEVEL DEBUG_LOG_LEVEL
+#define MAX_LOG_LEVEL INFO_LOG_LEVEL
 #include "logger.h"
 
 static int fd = -1;
@@ -143,7 +143,7 @@ int Serial_close()
 
     if (close(fd) < 0)
     {
-        LOGD("Error %d closing serial link: %s\n", errno, strerror (errno));
+        LOGW("Error %d closing serial link: %s\n", errno, strerror (errno));
         return -1;
     }
 

--- a/lib/wpc/include/wpc_internal.h
+++ b/lib/wpc/include/wpc_internal.h
@@ -8,6 +8,15 @@
 
 #include "wpc_types.h"
 
+typedef enum {
+    WPC_INT_GEN_ERROR = -1,          //< Generic error code
+    WPC_INT_TIMEOUT_ERROR = -2,      //< Timeout error
+    WPC_INT_SYNC_ERROR = -3,         //< Synchronization error
+    WPC_INT_WRONG_PARAM_ERROR = -4,  //< Wrong parameter
+    WPC_INT_WRONG_CRC = -5,          //< Wrong crc
+    WPC_INT_WRONG_BUFFER_SIZE = -6,  //< Wrong provided buffer size
+} WPC_Int_error_code_e;
+
 /**
  * \brief   Callback to be called when an indication is received
  * \param   frame


### PR DESCRIPTION
When a node exchanges a scatchpad to one of its neighbors,
the dual mcu is not able to serve UART requests.
And dual mcu app for now doesn't discard old requests from
host. So better handle this situation to avoid detecting an
uart issue when it is just an OTAP exchange.

Also remove some redundant traces (especially printing
received buffers).