### PR TITLE
explicitly initialize pthread_mutexattr_t

### DIFF
--- a/lib/platform/linux/platform.c
+++ b/lib/platform/linux/platform.c
@@ -280,6 +280,7 @@ bool Platform_init()
      * to protect the access to critical sections.
      */
     pthread_mutexattr_t attr;
+    pthread_mutexattr_init(&attr);
     pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK);
 
     // Initialize mutex to access critical section


### PR DESCRIPTION
Not initializing an instance of pthread_mutexattr_t can lead to
undefined behaviour within the pthread implementation.
For example with the musl libc this has triggered ENOTRECOVERABLE in
pthread_mutex_lock.