### PR TITLE
Max poll fail duration

### DIFF
--- a/lib/api/wpc.h
+++ b/lib/api/wpc.h
@@ -229,6 +229,14 @@ app_res_e WPC_initialize(char * port_name, unsigned long bitrate);
 void WPC_close(void);
 
 /**
+ * \brief   Set maximum poll fail duration
+ * \param   duration
+ *          the maximum poll fail duration
+ * \return  Return code of the operation
+ */
+app_res_e WPC_set_max_poll_fail_duration(unsigned long duration);
+
+/**
  * \brief   Get the role of the node
  * \param   app_role_e
  *          Pointer to store the result

--- a/lib/api/wpc.h
+++ b/lib/api/wpc.h
@@ -230,11 +230,12 @@ void WPC_close(void);
 
 /**
  * \brief   Set maximum poll fail duration
- * \param   duration
- *          the maximum poll fail duration
+ * \param   duration_s
+ *          the maximum poll fail duration in seconds,
+ *          zero equals forever
  * \return  Return code of the operation
  */
-app_res_e WPC_set_max_poll_fail_duration(unsigned long duration);
+app_res_e WPC_set_max_poll_fail_duration(unsigned long duration_s);
 
 /**
  * \brief   Get the role of the node

--- a/lib/platform/linux/platform.c
+++ b/lib/platform/linux/platform.c
@@ -24,7 +24,7 @@
 // Maximum duration in s of failed poll request to declare the link broken
 // (unplugged) Set it to 0 to disable 60 sec is long period but it must cover
 // the OTAP exchange with neighbors that can be long with some profiles
-#define MAX_DURATION_POLL_FAIL_S 60
+#define DEFAULT_MAX_POLL_FAIL_DURATION_S 60
 
 // Mutex for sending, ie serial access
 static pthread_mutex_t sending_mutex;
@@ -35,11 +35,9 @@ static pthread_t thread_polling;
 // This thread is used to dispatch indication
 static pthread_t thread_dispatch;
 
-#if MAX_DURATION_POLL_FAIL_S != 0
 // Last successful poll request
 static time_t m_last_successful_poll_ts;
-static unsigned int max_poll_fail_duration;
-#endif
+static unsigned int m_max_poll_fail_duration_s;
 
 /*****************************************************************************/
 /*                Indication queue related variables                        */
@@ -224,23 +222,23 @@ static void * poll_for_indication(void * unused)
             wait_before_next_polling_ms = POLLING_INTERVAL_MS;
         }
 
-#if MAX_DURATION_POLL_FAIL_S != 0
-        if (get_ind_res >= 0 || get_ind_res == WPC_INT_SYNC_ERROR)
+        if ((m_max_poll_fail_duration_s > 0)
         {
-            // Poll request executed fine or at least com is working with sink,
-            // reset fail counter
-            m_last_successful_poll_ts = get_timestamp_s();
-        }
-        else
-        {
-            if ((max_poll_fail_duration) &&
-                (get_timestamp_s() - m_last_successful_poll_ts > max_poll_fail_duration))
+            if (get_ind_res >= 0 || get_ind_res == WPC_INT_SYNC_ERROR)
             {
-                // Poll request has failed for too long, just exit
-                break;
+                // Poll request executed fine or at least com is working with sink,
+                // reset fail counter
+                m_last_successful_poll_ts = get_timestamp_s();
+            }
+            else
+            {
+                if (get_timestamp_s() - m_last_successful_poll_ts > m_max_poll_fail_duration_s)
+                {
+                    // Poll request has failed for too long, just exit
+                    break;
+                }
             }
         }
-#endif
     }
 
     LOGE("Exiting polling thread\n");
@@ -323,10 +321,8 @@ bool Platform_init()
         goto error4;
     }
 
-#if MAX_DURATION_POLL_FAIL_S != 0
     m_last_successful_poll_ts = get_timestamp_s();
-    max_poll_fail_duration = MAX_DURATION_POLL_FAIL_S;
-#endif
+    m_max_poll_fail_duration_s = DEFAULT_MAX_POLL_FAIL_DURATION_S;
 
     return true;
 
@@ -340,14 +336,10 @@ error1:
     return false;
 }
 
-bool Platform_set_max_poll_fail_duration(unsigned long duration)
+bool Platform_set_max_poll_fail_duration(unsigned long duration_s)
 {
-#if MAX_DURATION_POLL_FAIL_S != 0
-    max_poll_fail_duration = duration;
+    m_max_poll_fail_duration_s = duration_s;
     return true;
-#else
-    return false;
-#endif
 }
 
 void Platform_close()

--- a/lib/platform/linux/platform.c
+++ b/lib/platform/linux/platform.c
@@ -38,6 +38,7 @@ static pthread_t thread_dispatch;
 #if MAX_DURATION_POLL_FAIL_S != 0
 // Last successful poll request
 static time_t m_last_successful_poll_ts;
+static unsigned int max_poll_fail_duration;
 #endif
 
 /*****************************************************************************/
@@ -232,7 +233,8 @@ static void * poll_for_indication(void * unused)
         }
         else
         {
-            if (get_timestamp_s() - m_last_successful_poll_ts > MAX_DURATION_POLL_FAIL_S)
+            if ((max_poll_fail_duration) &&
+                (get_timestamp_s() - m_last_successful_poll_ts > max_poll_fail_duration))
             {
                 // Poll request has failed for too long, just exit
                 break;
@@ -323,6 +325,7 @@ bool Platform_init()
 
 #if MAX_DURATION_POLL_FAIL_S != 0
     m_last_successful_poll_ts = get_timestamp_s();
+    max_poll_fail_duration = MAX_DURATION_POLL_FAIL_S;
 #endif
 
     return true;
@@ -335,6 +338,16 @@ error2:
     pthread_mutex_destroy(&sending_mutex);
 error1:
     return false;
+}
+
+bool Platform_set_max_poll_fail_duration(unsigned long duration)
+{
+#if MAX_DURATION_POLL_FAIL_S != 0
+    max_poll_fail_duration = duration;
+    return true;
+#else
+    return false;
+#endif
 }
 
 void Platform_close()

--- a/lib/platform/linux/platform.c
+++ b/lib/platform/linux/platform.c
@@ -222,7 +222,7 @@ static void * poll_for_indication(void * unused)
             wait_before_next_polling_ms = POLLING_INTERVAL_MS;
         }
 
-        if ((m_max_poll_fail_duration_s > 0)
+        if (m_max_poll_fail_duration_s > 0)
         {
             if (get_ind_res >= 0 || get_ind_res == WPC_INT_SYNC_ERROR)
             {

--- a/lib/platform/platform.h
+++ b/lib/platform/platform.h
@@ -38,10 +38,13 @@ void Platform_unlock_request();
 
 /**
  * \brief   Set maximum duration the poll requests are accepted to fail
+ * \param   duration_s
+ *          maximum duration the polling can fail before exit,
+ *          zero equals forever.
  * \return  true if setting is available in platform,
  *          false if setting is not available in platform
  */
-bool Platform_set_max_poll_fail_duration(unsigned long duration);
+bool Platform_set_max_poll_fail_duration(unsigned long duration_s);
 
 void Platform_close();
 

--- a/lib/platform/platform.h
+++ b/lib/platform/platform.h
@@ -36,6 +36,13 @@ bool Platform_lock_request();
  */
 void Platform_unlock_request();
 
+/**
+ * \brief   Set maximum duration the poll requests are accepted to fail
+ * \return  true if setting is available in platform,
+ *          false if setting is not available in platform
+ */
+bool Platform_set_max_poll_fail_duration(unsigned long duration);
+
 void Platform_close();
 
 #endif /* PLATFORM_H_ */

--- a/lib/wpc/wpc.c
+++ b/lib/wpc/wpc.c
@@ -71,9 +71,9 @@ static const app_res_e ATT_WRITE_ERROR_CODE_LUT[] = {
     APP_RES_ACCESS_DENIED       // 6
 };
 
-app_res_e WPC_set_max_poll_fail_duration(unsigned long duration)
+app_res_e WPC_set_max_poll_fail_duration(unsigned long duration_s)
 {
-    if (Platform_set_max_poll_fail_duration(duration))
+    if (Platform_set_max_poll_fail_duration(duration_s))
     {
         return APP_RES_OK;
     }

--- a/lib/wpc/wpc.c
+++ b/lib/wpc/wpc.c
@@ -71,6 +71,18 @@ static const app_res_e ATT_WRITE_ERROR_CODE_LUT[] = {
     APP_RES_ACCESS_DENIED       // 6
 };
 
+app_res_e WPC_set_max_poll_fail_duration(unsigned long duration)
+{
+    if (Platform_set_max_poll_fail_duration(duration))
+    {
+        return APP_RES_OK;
+    }
+    else
+    {
+        return APP_RES_ACCESS_DENIED;
+    }
+}
+
 app_res_e WPC_get_role(app_role_t * role_p)
 {
     int res = csap_attribute_read_request(C_NODE_ROLE_ID, 1, role_p);


### PR DESCRIPTION
Add method to define max poll fail duration at run time

Method to define max poll fail duration at run time. duration=0 equals forever.
