### PR TITLE
Fix set max poll fail duration when changing from zero

### DIFF
--- a/lib/platform/linux/platform.c
+++ b/lib/platform/linux/platform.c
@@ -338,6 +338,10 @@ error1:
 
 bool Platform_set_max_poll_fail_duration(unsigned long duration_s)
 {
+    if ((m_max_poll_fail_duration_s == 0) && (duration_s > 0 ))
+    {
+        m_last_successful_poll_ts = get_timestamp_s();
+    }
     m_max_poll_fail_duration_s = duration_s;
     return true;
 }

--- a/lib/platform/linux/platform.c
+++ b/lib/platform/linux/platform.c
@@ -338,7 +338,7 @@ error1:
 
 bool Platform_set_max_poll_fail_duration(unsigned long duration_s)
 {
-    if ((m_max_poll_fail_duration_s == 0) && (duration_s > 0 ))
+    if ((m_max_poll_fail_duration_s == 0) && (duration_s > 0))
     {
         m_last_successful_poll_ts = get_timestamp_s();
     }


### PR DESCRIPTION
In case max poll fail duration has been zero, successful polls has
not updated time of last successful poll. Thus when changing max
poll fail duration from zero to something greater than zero, the
timestamp of last successful poll has to be updated.

