### PR TITLE
Logger: modify the Log format

### DIFF
--- a/lib/platform/linux/logger.c
+++ b/lib/platform/linux/logger.c
@@ -8,21 +8,61 @@
 
 #include <time.h>
 
-static inline void get_timestamp(char timestamp[26])
-{
-    time_t ltime;
-    struct tm result;
+/* Full log level string  */
+static char DEBUG[] = "DEBUG";
+static char INFO[] = "INFO";
+static char WARNING[] = "WARNING";
+static char ERROR[] = "ERROR";
 
-    ltime = time(NULL);
-    localtime_r(&ltime, &result);
-    sprintf(timestamp, "%d:%d:%d", result.tm_hour, result.tm_min, result.tm_sec);
+static inline void get_timestamp(char timestamp[37])
+{
+    struct tm result;
+    long ms;
+    time_t s;
+    struct timespec spec;
+
+    clock_gettime(CLOCK_REALTIME, &spec);
+
+    s = spec.tv_sec;
+    localtime_r(&s, &result);
+
+    ms = spec.tv_nsec / 1.0e6;  // Convert nanoseconds to milliseconds
+
+    sprintf(timestamp,
+            "%d-%02d-%02d %02d:%02d:%02d,%03ld",
+            result.tm_year + 1900,  // tm_year is in year - 1900
+            result.tm_mon + 1,      // tm_mon is in [0-11]
+            result.tm_mday,
+            result.tm_hour,
+            result.tm_min,
+            result.tm_sec,
+            ms);
 }
 
 static inline void print_prefix(char level, char * module)
 {
-    char timestamp[26];
+    char timestamp[37];
+    char * full_level;
+
+    switch (level)
+    {
+        case ('D'):
+            full_level = DEBUG;
+            break;
+        case ('I'):
+            full_level = INFO;
+            break;
+        case ('W'):
+            full_level = WARNING;
+            break;
+        case ('E'):
+            full_level = ERROR;
+            break;
+        default:
+            full_level = &level;
+    }
     get_timestamp(timestamp);
-    printf("[%s][%s] %c:", module, timestamp, level);
+    printf("%s | [%s] %s:", timestamp, full_level, module);
 }
 
 void Platform_LOG(char level, char * module, char * format, va_list args)


### PR DESCRIPTION
Mofify log format for linux to be more alligned with transport module

Output example:

2019-11-4 17:11:24.109 | [INFO] Main:Starting Sink service:
	-Port is /dev/ttyACM0
	-Bitrate is 125000
	-Dbus Service name is com.wirepas.sink.sink0
2019-11-4 17:11:24.130 | [DEBUG] SERIAL:Custom bitrate set: 125000
2019-11-4 17:11:24.130 | [INFO] wpc_int:WPC initialized
2019-11-4 17:11:24.138 | [INFO] Main:Node is running mesh API version 12

