### PR TITLE
Stop stack: avoid timeout error

### DIFF
--- a/lib/platform/platform.h
+++ b/lib/platform/platform.h
@@ -46,6 +46,16 @@ void Platform_unlock_request();
  */
 bool Platform_set_max_poll_fail_duration(unsigned long duration_s);
 
+/**
+ * \brief   Disable/Enable the poll requests
+ * \param   disabled
+ *          true to disable the poll request
+ *          false to enable it again
+ * \Note    It is mainly in case of periodic polling to be disabled
+ *          when we know that sink is not able to answer (when rebooting node)
+ */
+bool Platform_disable_poll_request(bool disabled);
+
 void Platform_close();
 
 #endif /* PLATFORM_H_ */


### PR DESCRIPTION
As we know that a stop stack generate a reboot of the node,
stop polling during the reboot and wait a bit before checking
node status.

It avoids errors in log that may be misinterpreted by users.


