### PR TITLE
Serial: try to reconnect to serial on write error

### DIFF
--- a/lib/platform/platform.h
+++ b/lib/platform/platform.h
@@ -6,6 +6,8 @@
 #ifndef PLATFORM_H_
 #define PLATFORM_H_
 
+#include <stdbool.h>
+
 bool Platform_init();
 
 void Platform_usleep(unsigned int time_us);


### PR DESCRIPTION
It is particularly usefull in case of USB connection as a
reboot of the board will close the serial link.
Reconnection is tried forever but there is a higher level
mechanism that close the program in case of too long interruption
in the communication with the sink (60s without successful poll).

Closes # .

*Brief pull request description*
