### PR TITLE
Fix regression from previous commit

### DIFF
--- a/lib/platform/linux/platform.c
+++ b/lib/platform/linux/platform.c
@@ -265,7 +265,7 @@ static void * poll_for_indication(void * unused)
                 {
                     // Poll request has failed for too long
                     // This is a fatal error as the com with sink was not possible
-                    // for a too lonk period.
+                    // for a too long period.
                     exit(EXIT_FAILURE);
                     break;
                 }

--- a/lib/platform/linux/platform.c
+++ b/lib/platform/linux/platform.c
@@ -263,7 +263,10 @@ static void * poll_for_indication(void * unused)
             {
                 if (get_timestamp_s() - m_last_successful_poll_ts > m_max_poll_fail_duration_s)
                 {
-                    // Poll request has failed for too long, just exit
+                    // Poll request has failed for too long
+                    // This is a fatal error as the com with sink was not possible
+                    // for a too lonk period.
+                    exit(EXIT_FAILURE);
                     break;
                 }
             }


### PR DESCRIPTION
In case of long communication break with sink,
just exit the full process.
It is still not the best option as it should be
reported with a callback to the one that open the lib
but at least it fix the regression introduced with previous
version.
In fact if a sink was unplugged, after 60s, the polling thread was
exiting but nothing else, having the lib still open without any
polling.
