### PR TITLE
Sink detection: better handle when sink do not respond

### DIFF
--- a/lib/platform/linux/platform.c
+++ b/lib/platform/linux/platform.c
@@ -390,6 +390,11 @@ bool Platform_set_max_poll_fail_duration(unsigned long duration_s)
     return true;
 }
 
+void Platform_valid_message_from_node()
+{
+    m_last_successful_poll_ts = get_timestamp_s();
+}
+
 bool Platform_disable_poll_request(bool disabled)
 {
     int res;

--- a/lib/platform/platform.h
+++ b/lib/platform/platform.h
@@ -58,6 +58,14 @@ bool Platform_set_max_poll_fail_duration(unsigned long duration_s);
  */
 bool Platform_disable_poll_request(bool disabled);
 
+/**
+ * \brief   Inform platform part that a message was received correctly from node.
+ * \Note    Without it, only poll request are taken into account and sometimes
+ *          between two consecutive scratchpad exchanges, there is no poll request
+ *          so the timeout is not reseted.
+ */
+void Platform_valid_message_from_node();
+
 void Platform_close();
 
 #endif /* PLATFORM_H_ */

--- a/lib/wpc/wpc_internal.c
+++ b/lib/wpc/wpc_internal.c
@@ -118,6 +118,9 @@ static int send_request_locked(wpc_frame_t * request, wpc_frame_t * confirm, uin
             return confirm_size;
         }
 
+        // Even if it doesn't match, the node sent something so it is alive
+        Platform_valid_message_from_node();
+
         // Check the confirm
         rec_confirm = (wpc_frame_t *) buffer;
         if ((rec_confirm->primitive_id) != (request->primitive_id + SAP_CONFIRM_OFFSET))


### PR DESCRIPTION
This is a workaround before a most robust solution.
Any succesfull poll request was considered as a heartbeat
form sink. Now consider any valid received message as a heartbeat.

In fact during otap exchanges, sink can stay silent for more than
30 seconds. And if two otap exchanges are following very quickly without
the oportunity of sending a poll confirm, sink can be silent for more
than 60s (lenght of the timeout).
This fix just reset the timeout with any messages to reduce the risk.
But the final solution should be on dual mcu side to send a busy signal
in such situation.

