### PR TITLE
Add support for setting and querying reserved channels mask

### DIFF
--- a/lib/api/wpc.h
+++ b/lib/api/wpc.h
@@ -221,6 +221,11 @@ typedef struct
 } app_nbors_t;
 
 /**
+ * \brief   Maximum number of bytes to give to WPC_(set|get)_reserved_channels()
+ */
+#define RESERVED_CHANNELS_MAX_NUM_BYTES 16
+
+/**
  * \brief   Intialize the Wirepas Mesh serial communication
  * \param   port_name
  *          the name of the serial port ("/dev/ttyACM0" for example)
@@ -440,6 +445,38 @@ app_res_e WPC_get_channel_map(uint32_t * value_p);
  * \return  Return code of the operation
  */
 app_res_e WPC_set_channel_map(uint32_t channel_map);
+
+/**
+ * \brief   Get reserved channels mask
+ * \param   channels_p
+ *          Pointer to store the reserved channels bit array
+ *          Each set bit marks the channel as reserved
+ *          LSB of first byte is channel 1, MSB of first byte is channel 7,
+ *          LSB of second byte is channel 8, an so on
+ * \param   size
+ *          Number of bytes pointed by @p channels_p, up to
+ *          @ref RESERVED_CHANNELS_MAX_NUM_BYTES
+ * \return  Return code of the operation
+ * \note    @p size Must be large enough to contain the highest reserved
+ *          channel bit, otherwise APP_RES_INVALID_VALUE is returned
+ */
+app_res_e WPC_get_reserved_channels(uint8_t * channels_p, uint8_t size);
+
+/**
+ * \brief   Set reserved channels mask
+ * \param   channels_p
+ *          Pointer to bit array to load the reserved channels
+ *          Each set bit marks the channel as reserved
+ *          LSB of first byte is channel 1, MSB of first byte is channel 7,
+ *          LSB of second byte is channel 8, an so on
+ * \param   size
+ *          Number of bytes pointed by @p channels_p, up to
+ *          @ref RESERVED_CHANNELS_MAX_NUM_BYTES
+ * \return  Return code of the operation
+ * \note    if @p size is smaller than needed for the available number of
+ *          channels, the remaining channels are set as not reserved
+ */
+app_res_e WPC_set_reserved_channels(const uint8_t * channels_p, uint8_t size);
 
 /**
  * \brief   Start the stack

--- a/lib/wpc/attribute.c
+++ b/lib/wpc/attribute.c
@@ -70,9 +70,10 @@ int attribute_read_request(uint8_t primitive_id,
 
     if (confirm.payload.attribute_read_confirm_payload.result == 0)
     {
-        if (attribute_length != confirm.payload.attribute_read_confirm_payload.attribute_length)
+        uint8_t actual_size = confirm.payload.attribute_read_confirm_payload.attribute_length;
+        if (attribute_length != actual_size)
         {
-            LOGE("Attribute read: wrong attribute size\n");
+            LOGE("Attribute read: wrong attribute size (%u received)\n", actual_size);
             return -1;
         }
         memcpy(attribute_value_p,

--- a/lib/wpc/include/csap.h
+++ b/lib/wpc/include/csap.h
@@ -33,6 +33,7 @@
 #define C_CHANNEL_MAP 21
 #define C_FEATURE_LOCK_BITS 22
 #define C_FEATURE_LOCK_KEY 23
+#define C_RESERVED_CHANNELS 25
 
 typedef struct __attribute__((__packed__))
 {

--- a/lib/wpc/wpc.c
+++ b/lib/wpc/wpc.c
@@ -375,6 +375,34 @@ app_res_e WPC_set_channel_map(uint32_t channel_map)
     return convert_error_code(ATT_WRITE_ERROR_CODE_LUT, res);
 }
 
+app_res_e WPC_get_reserved_channels(uint8_t * channels_p, uint8_t size)
+{
+    if (size > RESERVED_CHANNELS_MAX_NUM_BYTES)
+    {
+        return APP_RES_INVALID_VALUE;
+    }
+
+    memset(channels_p, 0, size);  // Clear unused bits
+    int res = csap_attribute_read_request(C_RESERVED_CHANNELS, size, channels_p);
+    if (res == 4)  // ATTR_INV_VALUE from the Dual-MCU app
+    {
+        // Not enough space to store set bits
+        return APP_RES_INVALID_VALUE;
+    }
+    return CONVERT_ERROR_CODE(ATT_READ_ERROR_CODE_LUT, res);
+}
+
+app_res_e WPC_set_reserved_channels(const uint8_t * channels_p, uint8_t size)
+{
+    if (size > RESERVED_CHANNELS_MAX_NUM_BYTES)
+    {
+        return APP_RES_INVALID_VALUE;
+    }
+
+    int res = csap_attribute_write_request(C_RESERVED_CHANNELS, size, channels_p);
+    return CONVERT_ERROR_CODE(ATT_WRITE_ERROR_CODE_LUT, res);
+}
+
 /* Error code LUT for app_config read */
 static const app_res_e APP_CONFIG_READ_ERROR_CODE_LUT[] = {
     APP_RES_OK,            // 0


### PR DESCRIPTION
Version 5.1.0.41 of the Dual-MCU app added support for reserving certain
radio channels from being used by the Wirepas Mesh stack. This commit
implements that support here, in the form of two new functions:
WPC_get_reserved_channels() and WPC_set_reserved_channels().
