### PR TITLE
Add support for setting and querying multicast group addresses

### DIFF
--- a/lib/api/wpc.h
+++ b/lib/api/wpc.h
@@ -207,6 +207,11 @@ typedef struct
 #define MAXIMUM_NUMBER_OF_NEIGHBOR 8
 
 /**
+ * \brief   Maximum number of multicast groups for MSAP_MULTICAST_GROUPS
+ */
+#define MAXIMUM_NUMBER_OF_MULTICAST_GROUPS 10
+
+/**
  * \brief   Neighbors info list
  */
 typedef struct
@@ -670,6 +675,36 @@ app_res_e WPC_get_current_access_cycle(uint16_t * cur_ac_p);
  * \return  Return code of the operation
  */
 app_res_e WPC_get_scratchpad_block_max(uint8_t * max_size_p);
+
+/**
+ * \brief   Get multicast group addresses
+ * \param   addr_list
+ *          An array of multicast addresses
+ *          Contents valid if return code is APP_RES_OK
+ * \param   num_addr_p
+ *          Pointer to the size of addr_list expressed in number of addresses.
+ *          If return code is APP_RES_OK, value will be set to the number of
+ *          addresses supported, even if not all of them fit in addr_list
+ * \return  Return code of the operation
+ * \note    Returned multicast addresses are in range 0x80000001-0x80FFFFFF,
+ *          or 0x00000000 (zero) for any item in the list not in use. Zero
+ *          addresses can appear anywhere in the list
+ */
+app_res_e WPC_get_multicast_groups(app_addr_t * addr_list, uint8_t * num_addr_p);
+
+/**
+ * \brief   Set multicast group addresses
+ * \param   addr_list
+ *          An array of multicast addresses
+ * \param   num_addr
+ *          Size of addr_list expressed in number of addresses, maximum of
+ *          MAXIMUM_NUMBER_OF_MULTICAST_GROUPS
+ * \return  Return code of the operation
+ * \note    Multicast addresses must be in range 0x80000001-0x80FFFFFF,
+ *          or 0x00000000 (zero) for any item in the list not in use. Zero
+ *          addresses can appear anywhere in the list
+ */
+app_res_e WPC_set_multicast_groups(const app_addr_t * addr_list, uint8_t num_addr);
 
 /**
  * \brief   Get the local scratchpad status

--- a/lib/wpc/attribute.c
+++ b/lib/wpc/attribute.c
@@ -20,7 +20,7 @@ int attribute_write_request(uint8_t primitive_id,
     int res;
     wpc_frame_t request, confirm;
 
-    if (attribute_length > 16)
+    if (attribute_length > MAX_ATTRIBUTE_SIZE)
         return -1;
 
     request.primitive_id = primitive_id;
@@ -32,7 +32,8 @@ int attribute_write_request(uint8_t primitive_id,
            attribute_value_p,
            attribute_length);
 
-    request.payload_length = sizeof(attribute_write_req_pl_t) - (16 - attribute_length);
+    request.payload_length =
+        sizeof(attribute_write_req_pl_t) - (MAX_ATTRIBUTE_SIZE - attribute_length);
 
     res = WPC_Int_send_request(&request, &confirm);
 

--- a/lib/wpc/include/attribute.h
+++ b/lib/wpc/include/attribute.h
@@ -16,11 +16,14 @@
 
 #include <stdint.h>
 
+// Maximum number of bytes in an attribute
+#define MAX_ATTRIBUTE_SIZE 40
+
 typedef struct __attribute__((__packed__))
 {
     uint16_t attribute_id;
     uint8_t attribute_length;
-    uint8_t attribute_value[16];
+    uint8_t attribute_value[MAX_ATTRIBUTE_SIZE];
 } attribute_write_req_pl_t;
 
 typedef struct __attribute__((__packed__))
@@ -33,7 +36,7 @@ typedef struct __attribute__((__packed__))
     uint8_t result;
     uint16_t attribute_id;
     uint8_t attribute_length;
-    uint8_t attribute_value[16];
+    uint8_t attribute_value[MAX_ATTRIBUTE_SIZE];
 } attribute_read_conf_pl_t;
 
 /**

--- a/lib/wpc/include/msap.h
+++ b/lib/wpc/include/msap.h
@@ -25,12 +25,16 @@
 #define MSAP_ACCESS_CYCLE_LIMITS 10
 #define MSAP_CURRENT_ACCESS_CYCLE 11
 #define MSAP_SCRATCHPAD_BLOCK_MAX 12
+#define MSAP_MULTICAST_GROUPS 13
 
 /* General constant */
 #define MAXIMUM_SCRATCHPAD_BLOCK_SIZE 112
 
 /* Maximum number of neighbors in a */
 #define MAXIMUM_NUMBER_OF_NEIGHBOR 8
+
+/* Maximum number of multicast groups for MSAP_MULTICAST_GROUPS */
+#define MAXIMUM_NUMBER_OF_MULTICAST_GROUPS 10
 
 #ifdef LEGACY_APP_CONFIG
 #    define MAXIMUM_APP_CONFIG_SIZE 16


### PR DESCRIPTION
Dual-MCU app supports setting up to 10 multicast group addresses for the
node. This commit implements multicast address support with two new
functions: WPC_get_multicast_groups() and WPC_set_multicast_groups().