### PR TITLE
Data registration: register for all data

### DIFF
--- a/example/main.c
+++ b/example/main.c
@@ -45,22 +45,6 @@ static bool onDataReceived(const uint8_t * bytes,
     return true;
 }
 
-static bool onDiagReceived(const uint8_t * bytes,
-                           uint8_t num_bytes,
-                           app_addr_t src_addr,
-                           app_addr_t dst_addr,
-                           app_qos_e qos,
-                           uint8_t src_ep,
-                           uint8_t dst_ep,
-                           uint32_t travel_time,
-                           uint8_t hop_count,
-                           unsigned long long timestamp_ms_epoch)
-{
-    // Handle diag packet here
-
-    return true;
-}
-
 int main(int argc, char * argv[])
 {
     app_res_e res;
@@ -89,10 +73,8 @@ int main(int argc, char * argv[])
 
     LOGI("Stack is stopped\n");
 
-    // Register for all datas from EP 50
-    WPC_register_for_data(50, onDataReceived);
-    // Register for all diagnostics from EP 255
-    WPC_register_for_data(255, onDiagReceived);
+    // Register for all datas
+    WPC_register_for_data(onDataReceived);
 
     // Configure the node
     if (WPC_set_node_address(NODE_ADDRESS) != APP_RES_OK)

--- a/lib/api/wpc.h
+++ b/lib/api/wpc.h
@@ -950,6 +950,7 @@ typedef bool (*onDataReceived_cb_f)(const uint8_t * bytes,
                                     uint8_t hop_count,
                                     unsigned long long timestamp_ms_epoch);
 
+#ifdef REGISTER_DATA_PER_ENDPOINT
 /**
  * \brief   Register for receiving data on a given EP
  * \param   dst_ep
@@ -970,7 +971,23 @@ app_res_e WPC_register_for_data(uint8_t dst_ep, onDataReceived_cb_f onDataReceiv
  * \return  Return code of the operation
  */
 app_res_e WPC_unregister_for_data(uint8_t dst_ep);
+#else
+/**
+ * \brief   Register for receiving all data
+ * \param   onDataReceived
+ *          The callback to call when data is received
+ * \note    The callback is called on a dedicated thread.
+ */
+app_res_e WPC_register_for_data(onDataReceived_cb_f onDataReceived);
 
+/**
+ * \brief   Unregister from receiving data
+ * \param   dst_ep
+ *          The destination endpoint to unregister
+ * \return  Return code of the operation
+ */
+app_res_e WPC_unregister_for_data();
+#endif
 /**
  * \brief   Callback definition to register for remote status update
  * \param   source_address

--- a/lib/makefile
+++ b/lib/makefile
@@ -15,6 +15,9 @@ CFLAGS  := -std=gnu99 -Wall -Werror
 # Uncomment the following line only if running with an old stack
 #CFLAGS  += -DLEGACY_APP_CONFIG
 
+# Uncomment the following line if you want the per endoint data reception
+#CFLAGS  += -DREGISTER_DATA_PER_ENDPOINT
+
 # Targets definition
 LIB_NAME := mesh_api_lib.a
 

--- a/lib/wpc/dsap.c
+++ b/lib/wpc/dsap.c
@@ -242,7 +242,7 @@ void dsap_data_rx_indication_handler(dsap_data_rx_ind_pl_t * payload,
     // Get the number of hops
     hop_count = payload->qos_hop_count >> 2;
 
-    // Someone is registered on this endpoint
+    // Call the registered callback
     cb(payload->apdu,
        payload->apdu_length,
        payload->src_add,

--- a/lib/wpc/dsap.c
+++ b/lib/wpc/dsap.c
@@ -13,8 +13,12 @@
 
 #include "string.h"
 
+#ifdef REGISTER_DATA_PER_ENDPOINT
 // Table to store the registered client callbacks for Rx data
 static onDataReceived_cb_f data_cb_table[MAX_NUMBER_EP];
+#else
+static onDataReceived_cb_f m_data_cb;
+#endif
 
 typedef struct
 {
@@ -206,6 +210,7 @@ void dsap_data_rx_indication_handler(dsap_data_rx_ind_pl_t * payload,
     uint32_t internal_travel_time = uint32_decode_le((uint8_t *) &(payload->travel_time));
     app_qos_e qos;
     uint8_t hop_count;
+    onDataReceived_cb_f cb;
 
     LOGI("Data received: indication_status = %d, src_add = %d, lenght=%u, "
          "travel time = %d, dst_ep = %d, ts=%llu\n",
@@ -216,32 +221,41 @@ void dsap_data_rx_indication_handler(dsap_data_rx_ind_pl_t * payload,
          payload->dest_endpoint,
          timestamp_ms_epoch);
 
-    if (data_cb_table[payload->dest_endpoint] != 0)
+#ifdef REGISTER_DATA_PER_ENDPOINT
+    cb = data_cb_table[payload->dest_endpoint];
+#else
+    cb = m_data_cb;
+#endif
+    if (cb == NULL)
     {
-        // Create the qos
-        qos = APP_QOS_NORMAL;
-        if (payload->qos_hop_count & 0x01)
-        {
-            qos = APP_QOS_HIGH;
-        }
-
-        // Get the number of hops
-        hop_count = payload->qos_hop_count >> 2;
-
-        // Someone is registered on this endpoint
-        data_cb_table[payload->dest_endpoint](payload->apdu,
-                                              payload->apdu_length,
-                                              payload->src_add,
-                                              payload->dest_add,
-                                              qos,
-                                              payload->src_endpoint,
-                                              payload->dest_endpoint,
-                                              internal_time_to_ms(internal_travel_time),
-                                              hop_count,
-                                              timestamp_ms_epoch);
+        // No cb registered
+        return;
     }
+
+    // Create the qos
+    qos = APP_QOS_NORMAL;
+    if (payload->qos_hop_count & 0x01)
+    {
+        qos = APP_QOS_HIGH;
+    }
+
+    // Get the number of hops
+    hop_count = payload->qos_hop_count >> 2;
+
+    // Someone is registered on this endpoint
+    cb(payload->apdu,
+       payload->apdu_length,
+       payload->src_add,
+       payload->dest_add,
+       qos,
+       payload->src_endpoint,
+       payload->dest_endpoint,
+       internal_time_to_ms(internal_travel_time),
+       hop_count,
+       timestamp_ms_epoch);
 }
 
+#ifdef REGISTER_DATA_PER_ENDPOINT
 bool dsap_register_for_data(uint8_t dst_ep, onDataReceived_cb_f onDataReceived)
 {
     bool ret = false;
@@ -271,10 +285,27 @@ bool dsap_unregister_for_data(uint8_t dst_ep)
 
     return ret;
 }
+#else
+bool dsap_register_for_data(onDataReceived_cb_f onDataReceived)
+{
+    m_data_cb = onDataReceived;
+    return true;
+}
+
+bool dsap_unregister_for_data()
+{
+    m_data_cb = NULL;
+    return true;
+}
+#endif
 
 void dsap_init()
 {
     // Initialize internal structures
+#ifdef REGISTER_DATA_PER_ENDPOINT
     memset(data_cb_table, 0, sizeof(data_cb_table));
+#else
+    m_data_cb = NULL;
+#endif
     memset(indication_sent_cb_table, 0, sizeof(indication_sent_cb_table));
 }

--- a/lib/wpc/include/dsap.h
+++ b/lib/wpc/include/dsap.h
@@ -122,6 +122,7 @@ void dsap_data_tx_indication_handler(dsap_data_tx_ind_pl_t * payload);
 void dsap_data_rx_indication_handler(dsap_data_rx_ind_pl_t * rx_indication,
                                      unsigned long long timestamp_ms_epoch);
 
+#ifdef REGISTER_DATA_PER_ENDPOINT
 /**
  * \brief   Register for receiving data on a given EP
  * \param   dst_ep
@@ -139,6 +140,21 @@ bool dsap_register_for_data(uint8_t dst_ep, onDataReceived_cb_f onDataReceived);
  * \return  True if success, false otherwise
  */
 bool dsap_unregister_for_data(uint8_t dst_ep);
+#else
+/**
+ * \brief   Register for receiving all
+ * \param   onDataReceived
+ *          The callback to call when data is received
+ * \return  True if success, false otherwise
+ */
+bool dsap_register_for_data(onDataReceived_cb_f onDataReceived);
+
+/**
+ * \brief   Unregister from receiving data
+ * \return  True if success, false otherwise
+ */
+bool dsap_unregister_for_data();
+#endif
 
 /**
  * \brief   Initialize the dsap module

--- a/lib/wpc/wpc.c
+++ b/lib/wpc/wpc.c
@@ -1119,6 +1119,7 @@ app_res_e WPC_send_data(const uint8_t * bytes,
     return WPC_send_data_with_options(&message);
 }
 
+#ifdef REGISTER_DATA_PER_ENDPOINT
 app_res_e WPC_register_for_data(uint8_t dst_ep, onDataReceived_cb_f onDataReceived)
 {
     return dsap_register_for_data(dst_ep, onDataReceived) ? APP_RES_OK : APP_RES_INVALID_VALUE;
@@ -1128,6 +1129,17 @@ app_res_e WPC_unregister_for_data(uint8_t dst_ep)
 {
     return dsap_unregister_for_data(dst_ep) ? APP_RES_OK : APP_RES_INVALID_VALUE;
 }
+#else
+app_res_e WPC_register_for_data(onDataReceived_cb_f onDataReceived)
+{
+    return dsap_register_for_data(onDataReceived) ? APP_RES_OK : APP_RES_INVALID_VALUE;
+}
+
+app_res_e WPC_unregister_for_data()
+{
+    return dsap_unregister_for_data() ? APP_RES_OK : APP_RES_INVALID_VALUE;
+}
+#endif
 
 app_res_e WPC_register_for_remote_status(onRemoteStatus_cb_f onRemoteStatusReceived)
 {


### PR DESCRIPTION
It is not that usefull to have a per EP data registration.
Dispatch will probably happen higher.
To simplify the code, make it as a compilation time flag.
By default if it is all data or nothing but it can still be change to
old behavior by defining REGISTER_DATA_PER_ENDPOINT flag.

