### PR TITLE
Stop stack: accept to lose the stop confirm

### DIFF
--- a/lib/wpc/wpc.c
+++ b/lib/wpc/wpc.c
@@ -570,11 +570,11 @@ app_res_e WPC_stop_stack(void)
 
     res = msap_stack_stop_request();
 
-    if (res < 0)
-    {
-        f_res = APP_RES_INTERNAL_ERROR;
-    }
-    else if (res == 1)
+    // res < 0 can happen if node reboot too early and doesn't
+    // have time to flush its buffer contatining stop request
+    // handle it as a normal case an try to obtain status after
+    // reboot
+    if (res == 1)
     {
         f_res = APP_RES_STACK_ALREADY_STOPPED;
     }


### PR DESCRIPTION
In case stack stop confirm is no received, still try
to obtain the stack status.

In fact, it can happen that the node reboot too quickly and
the response is not flushed to the uart line.

Relax a bit the requirement and accept to lose the confirm.

Closes # .

*Brief pull request description*
