### PR TITLE
Platform: add a Platform_get_timestamp_ms_monotonic API

### DIFF
--- a/lib/platform/linux/platform.c
+++ b/lib/platform/linux/platform.c
@@ -262,6 +262,15 @@ unsigned long long Platform_get_timestamp_ms_epoch()
     return ((unsigned long long) spec.tv_sec) * 1000 + (spec.tv_nsec) / 1000 / 1000;
 }
 
+unsigned long long Platform_get_timestamp_ms_monotonic()
+{
+    struct timespec spec;
+
+    // Get timestamp in ms since epoch
+    clock_gettime(CLOCK_MONOTONIC, &spec);
+    return ((unsigned long long) spec.tv_sec) * 1000 + (spec.tv_nsec) / 1000 / 1000;
+}
+
 void * Platform_malloc(size_t size)
 {
     LOGD("M: %d\n", size);

--- a/lib/platform/platform.h
+++ b/lib/platform/platform.h
@@ -69,6 +69,12 @@ bool Platform_init(Platform_get_indication_f get_indication_f,
 unsigned long long Platform_get_timestamp_ms_epoch();
 
 /**
+ * \brief   Get a monotonic timestamp in ms.
+ * \return  Monotonic timestamp when the call to this function is made
+ */
+unsigned long long Platform_get_timestamp_ms_monotonic();
+
+/**
  * \brief  Call at the beginning of a locked section to send a request
  * \Note   It is up to the platform implementation to see if
  *         this lock must be implemented or not. If all the requests

--- a/lib/wpc/dsap.c
+++ b/lib/wpc/dsap.c
@@ -394,11 +394,11 @@ void dsap_data_rx_frag_indication_handler(dsap_data_rx_frag_ind_pl_t * payload,
     // Do GC synchronously to avoid races as all fragment related actions happens on same thread
     // and no need for an another scheduling method to add in Platform
     if (m_fragment_max_duration_s > 0 &&
-        Platform_get_timestamp_ms_epoch() - last_gc_ts_ms > (MIN_GARBAGE_COLLECT_PERIOD_S * 1000))
+        Platform_get_timestamp_ms_monotonic() - last_gc_ts_ms > (MIN_GARBAGE_COLLECT_PERIOD_S * 1000))
     {
         // Time for a new GC
         reassembly_garbage_collect(m_fragment_max_duration_s);
-        last_gc_ts_ms = Platform_get_timestamp_ms_epoch();
+        last_gc_ts_ms = Platform_get_timestamp_ms_monotonic();
     }
 }
 

--- a/lib/wpc/reassembly/reassembly.c
+++ b/lib/wpc/reassembly/reassembly.c
@@ -47,8 +47,6 @@ typedef struct
     bool is_full;
     // List of already received frag
     internal_fragment_t *head;
-    // Timestamp of first fragment received
-    unsigned long long timestamp_ms_epoch_first;
     // Timestamp of last rx fragment received
     unsigned long long timestamp_ms_epoch_last;
     UT_hash_handle hh;
@@ -138,7 +136,7 @@ static bool add_fragment_to_full_packet(full_packet_t * full_packet_p, reassembl
     }
 
     // Update timestamp of latest fragment
-    full_packet_p->timestamp_ms_epoch_last = frag_p->timestamp;
+    full_packet_p->timestamp_ms_epoch_last = Platform_get_timestamp_ms_monotonic();
 
     return true;
 }
@@ -237,9 +235,6 @@ bool reassembly_add_fragment(reassembly_fragment_t * frag, size_t * full_size_p)
             LOGE("Cannot allocate packet from hash\n");
             return false;
         }
-
-        // Set timestamp for first fragment
-        full_packet_p->timestamp_ms_epoch_first = frag->timestamp;
     }
 
     // Now we have our full packet holder in full_packet_p
@@ -280,7 +275,7 @@ void reassembly_garbage_collect(uint32_t timeout_s)
     uint32_t messages_removed = 0;
     HASH_ITER(hh, m_packets, fp, tmp) {
         uint32_t last_activity =
-            (Platform_get_timestamp_ms_epoch() - fp->timestamp_ms_epoch_last) / 1000;
+            (Platform_get_timestamp_ms_monotonic() - fp->timestamp_ms_epoch_last) / 1000;
 
         /* Check if message is not getting too old */
         if (last_activity > timeout_s)

--- a/lib/wpc/wpc.c
+++ b/lib/wpc/wpc.c
@@ -14,7 +14,7 @@
 
 #include "wpc.h"  // For DEFAULT_BITRATE
 #include "wpc_internal.h"
-#include "platform.h"  // For Platform_get_timestamp_ms_epoch()
+#include "platform.h"  // For Platform_get_timestamp_ms_monotonic()
 
 /**
  * \brief   Macro to convert dual_mcu return code
@@ -519,9 +519,9 @@ static bool get_statck_status(uint16_t timeout_s)
     app_res_e res = APP_RES_INTERNAL_ERROR;
 
     // Compute timeout
-    unsigned long long timeout = Platform_get_timestamp_ms_epoch() + timeout_s * 1000;
+    unsigned long long timeout = Platform_get_timestamp_ms_monotonic() + timeout_s * 1000;
 
-    while (res != APP_RES_OK && Platform_get_timestamp_ms_epoch() < timeout)
+    while (res != APP_RES_OK && Platform_get_timestamp_ms_monotonic() < timeout)
     {
         res = WPC_get_stack_status(&status);
         LOGD("Cannot get status after start/stop, try again...\n");
@@ -604,8 +604,8 @@ app_res_e WPC_stop_stack(void)
         // Active wait of 500ms to avoid a systematic timeout
         // at each reboot. If status is asked immediately,
         // stack cannot answer
-        unsigned long long end_wait = Platform_get_timestamp_ms_epoch() + 500;
-        while (Platform_get_timestamp_ms_epoch() < end_wait)
+        unsigned long long end_wait = Platform_get_timestamp_ms_monotonic() + 500;
+        while (Platform_get_timestamp_ms_monotonic() < end_wait)
             ;
 
         // A stop of the stack will reboot the device

--- a/lib/wpc/wpc_internal.c
+++ b/lib/wpc/wpc_internal.c
@@ -99,7 +99,7 @@ static bool check_if_timeout_reached()
     // Check if it has failed for too long
     if (m_timeout_no_answer_ms > 0)
     {
-        if ((Platform_get_timestamp_ms_epoch() - m_last_successful_answer_ts) > m_timeout_no_answer_ms)
+        if ((Platform_get_timestamp_ms_monotonic() - m_last_successful_answer_ts) > m_timeout_no_answer_ms)
         {
             // Poll request has failed for too long
             // This is a fatal error as the com with sink was not possible
@@ -185,7 +185,7 @@ static int send_request_locked(wpc_frame_t * request, wpc_frame_t * confirm, uin
 
         // Even if it doesn't match, the node sent something so it is alive
         // Update our last activity
-        m_last_successful_answer_ts = Platform_get_timestamp_ms_epoch();
+        m_last_successful_answer_ts = Platform_get_timestamp_ms_monotonic();
 
         // Check the confirm
         rec_confirm = (wpc_frame_t *) buffer;
@@ -402,7 +402,7 @@ bool WPC_Int_set_timeout_s_no_answer(unsigned int duration_s)
     if ((m_timeout_no_answer_ms == 0) && (duration_s > 0))
     {
         // Initialize last activity to now (if it is first not enabled yet)
-        m_last_successful_answer_ts = Platform_get_timestamp_ms_epoch();
+        m_last_successful_answer_ts = Platform_get_timestamp_ms_monotonic();
     }
     m_timeout_no_answer_ms = duration_s * 1000;
     return true;
@@ -425,7 +425,7 @@ int WPC_Int_initialize(const char * port_name, unsigned long bitrate)
 
     dsap_init();
 
-    m_last_successful_answer_ts = Platform_get_timestamp_ms_epoch();
+    m_last_successful_answer_ts = Platform_get_timestamp_ms_monotonic();
 
     LOGI("WPC initialized\n");
     return 0;


### PR DESCRIPTION
The existing Platform_get_timestamp_ms_epoch is subject to ntp update and as is is often use to compute timeout, it may result to wrong behavior if the real time clock is changed during a timeout computation

