### PR TITLE
Explicitly added C libraries that can't be found when porting to another platform

### DIFF
--- a/lib/api/wpc.h
+++ b/lib/api/wpc.h
@@ -7,6 +7,7 @@
 #define WPC_H__
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 /**

--- a/lib/api/wpc_proto.h
+++ b/lib/api/wpc_proto.h
@@ -7,6 +7,7 @@
 #define WPC_PROTO_H__
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 /*

--- a/lib/wpc_proto/internal_modules/common.c
+++ b/lib/wpc_proto/internal_modules/common.c
@@ -3,6 +3,8 @@
  * See file LICENSE for full license details.
  *
  */
+#include <stdlib.h>
+
 #include "common.h"
 #include "platform.h"
 #include "wp_global.pb.h"


### PR DESCRIPTION
When porting to another platform it can be required to explicitly include all used libraries.