### PR TITLE
Platform: allow no_platform

### DIFF
--- a/lib/platform/linux/makefile
+++ b/lib/platform/linux/makefile
@@ -1,0 +1,10 @@
+# Sources for platform module
+PLATFORM_MODULE = $(SOURCEPREFIX)platform/linux
+
+SOURCES += $(PLATFORM_MODULE)/platform.c
+SOURCES += $(PLATFORM_MODULE)/serial.c
+SOURCES += $(PLATFORM_MODULE)/serial_termios2.c
+SOURCES += $(PLATFORM_MODULE)/logger.c
+
+# Add the reentrant flag as using pthread lib
+CFLAGS  += -D_REENTRANT

--- a/lib/platform/makefile
+++ b/lib/platform/makefile
@@ -1,13 +1,15 @@
 # Sources for platform module
 PLATFORM_MODULE = $(SOURCEPREFIX)platform/
 
-# For now, only support linux platform
-SOURCES += $(PLATFORM_MODULE)linux/platform.c
-SOURCES += $(PLATFORM_MODULE)linux/serial.c
-SOURCES += $(PLATFORM_MODULE)linux/serial_termios2.c
-SOURCES += $(PLATFORM_MODULE)linux/logger.c
-
-# Add the reentrant flag as using pthread lib
-CFLAGS  += -D_REENTRANT
-
 CFLAGS  += -I$(PLATFORM_MODULE)
+
+target_platform?=linux
+
+ifeq ($(target_platform),no)
+$(warning No plaftform selected)
+else ifneq ($(target_platform),)
+# Include the target_platform part
+include $(PLATFORM_MODULE)$(target_platform)/makefile
+else
+$(warning No plaftform selected)
+endif


### PR DESCRIPTION
make target_platform=no

make platform "optional"
It allows to implement the platform part in a different repo, and just use the c-mesh-api generic part from this repo

Note: linux is still the default target platform

Closes # .

*Brief pull request description*
