### PR TITLE
Correct potential compilation issue

### DIFF
--- a/lib/wpc_proto/internal_modules/common.c
+++ b/lib/wpc_proto/internal_modules/common.c
@@ -105,8 +105,8 @@ wp_ErrorCode Common_convert_error_code(app_res_e error)
 
 void Common_fill_event_header(wp_EventHeader * header_p)
 {
-    _Static_assert(member_size(wp_EventHeader, gw_id) >= GATEWAY_ID_MAX_SIZE);
-    _Static_assert(member_size(wp_EventHeader, sink_id) >= SINK_ID_MAX_SIZE);
+    _Static_assert(member_size(wp_EventHeader, gw_id) >= GATEWAY_ID_MAX_SIZE, "Gateway ID too long");
+    _Static_assert(member_size(wp_EventHeader, sink_id) >= SINK_ID_MAX_SIZE, "Sink ID too long");
 
     *header_p = (wp_EventHeader){
         .has_sink_id = (strlen(m_sink_id) != 0),
@@ -123,8 +123,8 @@ void Common_Fill_response_header(wp_ResponseHeader * header_p,
                                  uint64_t req_id,
                                  wp_ErrorCode res)
 {
-    _Static_assert(member_size(wp_ResponseHeader, gw_id) >= GATEWAY_ID_MAX_SIZE);
-    _Static_assert(member_size(wp_ResponseHeader, sink_id) >= SINK_ID_MAX_SIZE);
+    _Static_assert(member_size(wp_ResponseHeader, gw_id) >= GATEWAY_ID_MAX_SIZE, "Gateway ID too long");
+    _Static_assert(member_size(wp_ResponseHeader, sink_id) >= SINK_ID_MAX_SIZE, "Sink ID too long");
 
     *header_p = (wp_ResponseHeader) {
         .req_id = req_id,

--- a/lib/wpc_proto/internal_modules/proto_config.c
+++ b/lib/wpc_proto/internal_modules/proto_config.c
@@ -130,7 +130,7 @@ static app_role_t convert_role_to_app_format(wp_NodeRole * proto_role)
 
 static void convert_role_to_proto_format(app_role_t role, wp_NodeRole * proto_role)
 {
-    _Static_assert(member_size(wp_NodeRole, flags) >= (2 * sizeof(wp_NodeRole_RoleFlags)) );
+    _Static_assert(member_size(wp_NodeRole, flags) >= (2 * sizeof(wp_NodeRole_RoleFlags)), "Too many role flags");
 
     pb_size_t flags_count = 0;
     proto_role->role = GET_BASE_ROLE(role);
@@ -322,9 +322,10 @@ static void fill_target_and_action(wp_TargetScratchpadAndAction * target_and_act
 
 static void fill_sink_read_config(wp_SinkReadConfig * config_p)
 {
-    _Static_assert( member_size(wp_AppConfigData_app_config_data_t, bytes)
-                    >= member_size(msap_app_config_data_write_req_pl_t, app_config_data));
-    _Static_assert(member_size(wp_SinkReadConfig, sink_id) >= SINK_ID_MAX_SIZE);
+    _Static_assert(     member_size(wp_AppConfigData_app_config_data_t, bytes)
+                     >= member_size(msap_app_config_data_write_req_pl_t, app_config_data),
+                      "wp_AppConfigData_app_config_data_t is too small");
+    _Static_assert(member_size(wp_SinkReadConfig, sink_id) >= SINK_ID_MAX_SIZE, "wp_SinkReadConfig is too small");
 
     uint8_t status = m_sink_config.StackStatus;
 
@@ -418,8 +419,8 @@ static void fill_status_event(wp_StatusEvent * status_event_p,
                                  wp_OnOffState state,
                                  pb_size_t config_count)
 {
-    _Static_assert(member_size(wp_StatusEvent, gw_model) >= GATEWAY_MODEL_MAX_SIZE);
-    _Static_assert(member_size(wp_StatusEvent, gw_version) >= GATEWAY_VERSION_MAX_SIZE);
+    _Static_assert(member_size(wp_StatusEvent, gw_model) >= GATEWAY_MODEL_MAX_SIZE, "Gateway model too big");
+    _Static_assert(member_size(wp_StatusEvent, gw_version) >= GATEWAY_VERSION_MAX_SIZE, "Gateway version too big");
 
     *status_event_p = (wp_StatusEvent){
         .version = GW_PROTO_MESSAGE_VERSION,
@@ -904,7 +905,7 @@ app_proto_res_e Proto_config_handle_set_scratchpad_target_and_action_request(
 {
     app_res_e res = APP_RES_OK;
     uint8_t seq;
-    uint8_t param;
+    uint8_t param = 0;
     uint16_t crc;
 
     // TODO: Add some sanity checks


### PR DESCRIPTION
Param could be used uninitialized
Static_assert required two parameters in C11
