### PR TITLE
Correct Error code conversion

### DIFF
--- a/example/linux/gw-example/makefile
+++ b/example/linux/gw-example/makefile
@@ -15,7 +15,7 @@ MESH_LIB_FOLDER := ../../../lib/
 MESH_LIB := $(MESH_LIB_FOLDER)build/mesh_api_lib.a
 
 # General compiler flags
-CFLAGS  := -std=gnu99 -Wall -Werror
+CFLAGS  := -std=gnu99 -Wall -Werror -Wenum-conversion
 
 # Targets definition
 MAIN_APP := gw-example

--- a/lib/makefile
+++ b/lib/makefile
@@ -11,7 +11,7 @@ SOURCEPREFIX   :=
 BUILDPREFIX    := build/
 
 # General compiler flags
-CFLAGS  := -std=gnu99 -Wall -Werror
+CFLAGS  := -std=gnu99 -Wall -Werror -Wenum-conversion
 # Uncomment the following line only if running with an old stack
 #CFLAGS  += -DLEGACY_APP_CONFIG
 

--- a/lib/wpc_proto/internal_modules/common.c
+++ b/lib/wpc_proto/internal_modules/common.c
@@ -129,7 +129,7 @@ void Common_Fill_response_header(wp_ResponseHeader * header_p,
     *header_p = (wp_ResponseHeader) {
         .req_id = req_id,
         .has_sink_id = (strlen(m_sink_id) != 0),
-        .res = Common_convert_error_code(res),
+        .res = res,
         .has_time_ms_epoch = true,
         .time_ms_epoch = Platform_get_timestamp_ms_epoch(),
     };

--- a/lib/wpc_proto/internal_modules/proto_config.c
+++ b/lib/wpc_proto/internal_modules/proto_config.c
@@ -894,7 +894,7 @@ app_proto_res_e Proto_config_handle_get_configs(wp_GetConfigsReq *req,
     // as config is available in cache, response is ok
     Common_Fill_response_header(&resp->header,
                                 req->header.req_id,
-                                Common_convert_error_code(APP_RES_OK));
+                                wp_ErrorCode_OK);
     resp->configs_count = 1;
     fill_sink_read_config(&resp->configs[0]);
 
@@ -908,7 +908,7 @@ app_proto_res_e Proto_config_handle_get_gateway_info_request(wp_GetGwInfoReq * r
 
     Common_Fill_response_header(&resp->header,
                                 req->header.req_id,
-                                Common_convert_error_code(APP_RES_OK));
+                                wp_ErrorCode_OK);
 
     resp->info.current_time_s_epoch = Platform_get_timestamp_ms_epoch();
 


### PR DESCRIPTION
Common_Fill_response_header should not call Common_convert_error_code internally, as res is already a wp_ErrorCode type.
Add build option to grab such errors.
