### PR TITLE
Dockerfile for gateway example

### DIFF
--- a/example/linux/gw-example/docker/Dockerfile
+++ b/example/linux/gw-example/docker/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.20 AS builder
+FROM alpine:3 AS builder
 
-RUN apk add --no-cache bash build-base gcc make paho-mqtt-c-dev
+RUN apk add --no-cache gcc make paho-mqtt-c-dev musl-dev linux-headers
 
 RUN adduser --disabled-password wirepas
 
@@ -10,10 +10,12 @@ WORKDIR /home/wirepas
 
 COPY --chown=wirepas ./ /home/wirepas/c-mesh-api
 WORKDIR /home/wirepas/c-mesh-api/example/linux/gw-example
-RUN make
+RUN make clean all
 
 # Build the final image
-FROM alpine:3.20
+FROM alpine:3
+
+ARG GATEWAY_BUILD_SHA1=unset
 
 RUN adduser --disabled-password wirepas
 RUN addgroup wirepas dialout
@@ -23,8 +25,8 @@ RUN apk add --no-cache paho-mqtt-c
 USER wirepas
 
 # Copy the built binary
-COPY --from=builder /home/wirepas/c-mesh-api/example/linux/gw-example/build/gw-example /home/wirepas/gw-example
+COPY --from=builder /home/wirepas/c-mesh-api/example/linux/gw-example/build/gw-example /usr/local/bin/gw-example
 
-CMD ["/home/wirepas/gw-example"]
+ENTRYPOINT ["gw-example"]
 
 LABEL com.wirepas.tiny_gateway.build.sha1="${GATEWAY_BUILD_SHA1}"

--- a/example/linux/gw-example/docker/Dockerfile
+++ b/example/linux/gw-example/docker/Dockerfile
@@ -1,0 +1,30 @@
+FROM alpine:3.20 AS builder
+
+RUN apk add --no-cache bash build-base gcc make paho-mqtt-c-dev
+
+RUN adduser --disabled-password wirepas
+
+USER wirepas
+
+WORKDIR /home/wirepas
+
+COPY --chown=wirepas ./ /home/wirepas/c-mesh-api
+WORKDIR /home/wirepas/c-mesh-api/example/linux/gw-example
+RUN make
+
+# Build the final image
+FROM alpine:3.20
+
+RUN adduser --disabled-password wirepas
+RUN addgroup wirepas dialout
+
+RUN apk add --no-cache paho-mqtt-c
+
+USER wirepas
+
+# Copy the built binary
+COPY --from=builder /home/wirepas/c-mesh-api/example/linux/gw-example/build/gw-example /home/wirepas/gw-example
+
+CMD ["/home/wirepas/gw-example"]
+
+LABEL com.wirepas.tiny_gateway.build.sha1="${GATEWAY_BUILD_SHA1}"

--- a/example/linux/gw-example/docker/Readme.md
+++ b/example/linux/gw-example/docker/Readme.md
@@ -1,0 +1,32 @@
+# Configuration
+Confugiration parameters can be passed to the container as command line
+parameters. See --help for the available parameters.
+
+```bash
+docker run --rm local/tiny_gateway --help
+```
+
+## Command line example
+
+```bash
+docker run --device /dev/ttyACM0:/dev/sink local/tiny_gateway \
+-p /dev/sink -b 125000 -g my-gateway-id -H mqtt.broker.example:8883 -U "username" -P "password"
+```
+
+## Docker compose example
+
+```yaml
+  gateway:
+    image: local/tiny_gateway:latest
+    container_name: gateway
+    command: >
+      -p /dev/sink
+      -b 125000
+      -g my-gateway-id
+      -H mqtt.broker.example:8883
+      -U "username"
+      -P "password"
+    devices:
+      - /dev/ttyACM0:/dev/sink
+```
+


### PR DESCRIPTION
Gateway configuration can be passed as command line parameters to the container, examples for that are available in the readme.

If we want to support environment variables so that it's similar to the linux gateway, we can add them later by either modifying the code or having a runner shell script in the container.