### PR TITLE
Update status after scratchpad action is set to NO_OTAP

### DIFF
--- a/lib/wpc_proto/internal_modules/proto_config.c
+++ b/lib/wpc_proto/internal_modules/proto_config.c
@@ -975,11 +975,15 @@ app_proto_res_e Proto_config_handle_set_scratchpad_target_and_action_request(
 
     // TODO: Add some sanity checks
 
+    LOGI("Set scratchpad target and action request received with action: %d\n",
+         req->target_and_action.action);
+
     switch (req->target_and_action.action) {
 
         case wp_ScratchpadAction_NO_OTAP :
             res = WPC_write_target_scratchpad(0, 0, 0, 0);
-            LOGI("Target and action pushed NoOtap\n", res);
+            // Read otap variable back to be sure everything is updated
+            initialize_otap_variables();
             break;
 
         case wp_ScratchpadAction_PROPAGATE_AND_PROCESS_WITH_DELAY :


### PR DESCRIPTION
Issue was discovered by @teemupiiroinenwirepas

Unlike other scratchpad actions, when the action was set to NO_OTAP, the otap parameters were not being read. This caused the gateway to respond with a wrong scratchpad action.

Also adding more logging to inform which scratchpad action is being set. If result is an error, it would be printed later.