### PR TITLE
C-mesh-API: Scalable key management CSAP attributes

### DIFF
--- a/lib/api/wpc.h
+++ b/lib/api/wpc.h
@@ -203,6 +203,17 @@ typedef struct
     bool is_unack_csma_ca;            //!< If true, only sent to CB-MAC nodes
 } app_message_t;
 
+// structure to hold security key pair
+typedef struct __attribute__((packed))
+{
+    struct
+    {
+        const uint8_t encryption[16];
+        const uint8_t authentication[16];
+    } key_pair;
+    uint8_t sequence_number; /**< Sequence number, 1-255 */
+} wpc_key_pair_t;
+
 /**
  * \brief   Maximum number of neighbors (defined in protocol)
  */
@@ -384,6 +395,24 @@ app_res_e WPC_remove_cipher_key();
  * \return  Return code of the operation
  */
 app_res_e WPC_set_authentication_key(const uint8_t key[16]);
+
+
+/**
+ * \brief   Set the network key pair
+ * \param   keypair
+ *          The new keypair to set
+ * \return  Return code of the operation
+ */
+app_res_e WPC_set_network_key_pair(const wpc_key_pair_t * key_pair);
+
+/**
+ * \brief   Set the management key pair
+ * \param   keypair
+ *          The new keypair to set
+ * \return  Return code of the operation
+ */
+app_res_e WPC_set_management_key_pair(const wpc_key_pair_t * key_pair);
+
 
 /**
  * \brief   Check if authentication key is set

--- a/lib/wpc/include/csap.h
+++ b/lib/wpc/include/csap.h
@@ -34,6 +34,9 @@
 #define C_FEATURE_LOCK_BITS 22
 #define C_FEATURE_LOCK_KEY 23
 #define C_RESERVED_CHANNELS 25
+#define C_NETWORK_KEY_PAIR_ID 26
+#define C_MANAGEMENT_KEY_PAIR_ID 27
+
 
 typedef struct __attribute__((__packed__))
 {

--- a/lib/wpc/wpc.c
+++ b/lib/wpc/wpc.c
@@ -432,6 +432,36 @@ app_res_e WPC_set_reserved_channels(const uint8_t * channels_p, uint8_t size)
     return convert_error_code(ATT_WRITE_ERROR_CODE_LUT, res);
 }
 
+
+static app_res_e set_key_pair(uint16_t attribute_id, const uint8_t * value)
+{
+    int res = csap_attribute_write_request(attribute_id, sizeof(wpc_key_pair_t), value);
+    return convert_error_code(ATT_WRITE_ERROR_CODE_LUT, res);
+} 
+
+
+app_res_e WPC_set_network_key_pair(const wpc_key_pair_t * key_pair)
+{
+    if (key_pair != NULL)
+    {
+        return set_key_pair(C_NETWORK_KEY_PAIR_ID, (const uint8_t *)key_pair);
+    }
+
+    return APP_RES_INTERNAL_ERROR;
+}
+
+
+app_res_e WPC_set_management_key_pair(const wpc_key_pair_t * key_pair)
+{
+    if (key_pair != NULL)
+    {
+        return set_key_pair(C_MANAGEMENT_KEY_PAIR_ID, (const uint8_t *)key_pair);
+    }
+
+    return APP_RES_INTERNAL_ERROR;
+}
+
+
 /* Error code LUT for app_config read */
 static const app_res_e APP_CONFIG_READ_ERROR_CODE_LUT[] = {
     APP_RES_OK,            // 0


### PR DESCRIPTION
New write-only CSAP attributes CSAP_ATTR_NETWORK_KEY_PAIR and CSAP_ATTR_MANAGEMENT_KEY_PAIR which are introduced in the DualMCU API version 21.

c-mesh-api interface:
app_res_e WPC_set_network_key_pair(const wpc_key_pair_t * key_pair); 
app_res_e WPC_set_management_key_pair(const wpc_key_pair_t * key_pair);

This interface is needed for the provisioning of initial security keys to the sink from the backend.
