### PR TITLE
CMake support

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -29,3 +29,36 @@ jobs:
     - name: make test
       run: make
       working-directory: test
+
+  build-with-cmake:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: checkout code
+      uses: actions/checkout@v4
+      with:
+        submodules: true
+    - name: build example
+      run: |
+          cmake -S . -B cbuild
+          cmake --build cbuild
+      working-directory: example
+    - name: make proto example
+      run: |
+          cmake -S . -B cbuild
+          cmake --build cbuild
+      working-directory: example/linux/proto-api
+    - name: install needed packages libpaho-mqtt
+      run: sudo apt-get update && sudo apt-get install -y libpaho-mqtt-dev
+    - name: build gateway example
+      run: |
+          cmake -S . -B cbuild
+          cmake --build cbuild
+      working-directory: example/linux/gw-example
+    - name: build test
+      run: |
+          cmake -S . -B cbuild
+          cmake --build cbuild
+      working-directory: test
+

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -11,14 +11,11 @@ set(WPC_LIB_DIR "${CMAKE_CURRENT_LIST_DIR}/../lib/")
 
 include(FetchContent)
 FetchContent_Declare(
-  wpc-lib
-  SOURCE_DIR ${WPC_LIB_DIR}
+    wpc-lib
+    SOURCE_DIR ${WPC_LIB_DIR}
 )
 FetchContent_MakeAvailable(wpc-lib)
 
 add_executable(${CMAKE_PROJECT_NAME} main.c)
-target_link_libraries(${CMAKE_PROJECT_NAME}
-    wpc
-    wpc_platform
-)
+target_link_libraries(${CMAKE_PROJECT_NAME} wpc)
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.18)
+
+project(meshAPIExample LANGUAGES C)
+
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_BUILD_TYPE RelWithDebInfo)
+
+add_compile_options(-Wall -Werror)
+
+set(WPC_LIB_DIR "${CMAKE_CURRENT_LIST_DIR}/../lib/")
+
+include(FetchContent)
+FetchContent_Declare(
+  wpc-lib
+  SOURCE_DIR ${WPC_LIB_DIR}
+)
+FetchContent_MakeAvailable(wpc-lib)
+
+add_executable(${CMAKE_PROJECT_NAME} main.c)
+target_link_libraries(${CMAKE_PROJECT_NAME}
+    wpc
+    wpc_platform
+)
+

--- a/example/linux/gw-example/CMakeLists.txt
+++ b/example/linux/gw-example/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.18)
+
+project(gw-example LANGUAGES C)
+
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_BUILD_TYPE RelWithDebInfo)
+
+add_compile_options(-Wall -Werror -Wenum-conversion -Wextra)
+
+set(WPC_LIB_DIR "${CMAKE_CURRENT_LIST_DIR}/../../../lib/")
+
+include(FetchContent)
+set(WPC_BUILD_PROTO_API ON)
+FetchContent_Declare(
+    wpc-lib
+    SOURCE_DIR ${WPC_LIB_DIR}
+)
+FetchContent_MakeAvailable(wpc-lib)
+
+find_library(paho paho-mqtt3cs REQUIRED)
+
+add_executable(${CMAKE_PROJECT_NAME} main.c)
+target_link_libraries(${CMAKE_PROJECT_NAME}
+    wpc_proto
+    paho-mqtt3cs
+)
+target_compile_options(${CMAKE_PROJECT_NAME} PRIVATE
+    -Wno-unused-parameter
+    -Wno-implicit-fallthrough
+)
+

--- a/example/linux/gw-example/docker/Dockerfile
+++ b/example/linux/gw-example/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3 AS builder
 
-RUN apk add --no-cache gcc make paho-mqtt-c-dev musl-dev linux-headers
+RUN apk add --no-cache gcc cmake make paho-mqtt-c-dev musl-dev linux-headers
 
 RUN adduser --disabled-password wirepas
 
@@ -9,8 +9,8 @@ USER wirepas
 WORKDIR /home/wirepas
 
 COPY --chown=wirepas ./ /home/wirepas/c-mesh-api
-WORKDIR /home/wirepas/c-mesh-api/example/linux/gw-example
-RUN make clean all
+RUN cmake -S /home/wirepas/c-mesh-api/example/linux/gw-example -B build
+RUN cmake --build build
 
 # Build the final image
 FROM alpine:3
@@ -25,7 +25,7 @@ RUN apk add --no-cache paho-mqtt-c
 USER wirepas
 
 # Copy the built binary
-COPY --from=builder /home/wirepas/c-mesh-api/example/linux/gw-example/build/gw-example /usr/local/bin/gw-example
+COPY --from=builder /home/wirepas/build/gw-example /usr/local/bin/gw-example
 
 ENTRYPOINT ["gw-example"]
 

--- a/example/linux/proto-api/CMakeLists.txt
+++ b/example/linux/proto-api/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.18)
+
+project(protoAPIExample LANGUAGES C)
+
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_BUILD_TYPE RelWithDebInfo)
+
+add_compile_options(-Wall -Werror -Wenum-conversion -Wextra)
+
+set(WPC_LIB_DIR "${CMAKE_CURRENT_LIST_DIR}/../../../lib/")
+
+include(FetchContent)
+set(WPC_BUILD_PROTO_API ON)
+FetchContent_Declare(
+    wpc-lib
+    SOURCE_DIR ${WPC_LIB_DIR}
+)
+FetchContent_MakeAvailable(wpc-lib)
+
+add_executable(${CMAKE_PROJECT_NAME} main.c)
+target_link_libraries(${CMAKE_PROJECT_NAME} wpc_proto)
+target_compile_options(${CMAKE_PROJECT_NAME} PRIVATE
+    -Wno-unused-parameter
+    -Wno-implicit-fallthrough
+)
+

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.18)
+
+project(c-mesh-api LANGUAGES C)
+
+set(WPC_PLATFORM "linux" CACHE STRING "Platform implementation")
+option(WPC_BUILD_PROTO_API "Build wpc_proto library" OFF)
+
+add_subdirectory(wpc)
+
+if(${WPC_PLATFORM} STREQUAL "linux")
+  add_subdirectory(platform/${WPC_PLATFORM})
+endif()
+
+if(WPC_BUILD_PROTO_API)
+  add_subdirectory(wpc_proto)
+endif()
+

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -8,10 +8,12 @@ option(WPC_BUILD_PROTO_API "Build wpc_proto library" OFF)
 add_subdirectory(wpc)
 
 if(${WPC_PLATFORM} STREQUAL "linux")
-  add_subdirectory(platform/${WPC_PLATFORM})
+    add_subdirectory(platform/${WPC_PLATFORM})
+    target_link_libraries(wpc wpc_platform)
 endif()
 
 if(WPC_BUILD_PROTO_API)
   add_subdirectory(wpc_proto)
+  target_link_libraries(wpc_proto wpc)
 endif()
 

--- a/lib/platform/linux/CMakeLists.txt
+++ b/lib/platform/linux/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_library(wpc_platform STATIC
+    ${CMAKE_CURRENT_LIST_DIR}/logger.c
+    ${CMAKE_CURRENT_LIST_DIR}/platform.c
+    ${CMAKE_CURRENT_LIST_DIR}/serial.c
+    ${CMAKE_CURRENT_LIST_DIR}/serial_termios2.c
+)
+
+target_include_directories(wpc_platform PRIVATE
+    ${PROJECT_SOURCE_DIR}/api
+    ${PROJECT_SOURCE_DIR}/platform
+    ${PROJECT_SOURCE_DIR}/wpc/include
+)
+
+find_package(Threads REQUIRED)
+target_link_libraries(wpc_platform PRIVATE Threads::Threads)
+

--- a/lib/wpc/CMakeLists.txt
+++ b/lib/wpc/CMakeLists.txt
@@ -1,0 +1,20 @@
+add_library(wpc STATIC
+    ${CMAKE_CURRENT_LIST_DIR}/attribute.c
+    ${CMAKE_CURRENT_LIST_DIR}/csap.c
+    ${CMAKE_CURRENT_LIST_DIR}/dsap.c
+    ${CMAKE_CURRENT_LIST_DIR}/msap.c
+    ${CMAKE_CURRENT_LIST_DIR}/slip.c
+    ${CMAKE_CURRENT_LIST_DIR}/wpc.c
+    ${CMAKE_CURRENT_LIST_DIR}/wpc_internal.c
+    ${CMAKE_CURRENT_LIST_DIR}/reassembly/reassembly.c
+)
+
+target_include_directories(wpc PUBLIC
+    ${PROJECT_SOURCE_DIR}/api
+)
+
+target_include_directories(wpc PRIVATE
+    ${PROJECT_SOURCE_DIR}/platform
+    ${CMAKE_CURRENT_LIST_DIR}/include
+)
+

--- a/lib/wpc_proto/CMakeLists.txt
+++ b/lib/wpc_proto/CMakeLists.txt
@@ -1,0 +1,52 @@
+set(GENERATED_PROTOS_FOLDER ${CMAKE_CURRENT_LIST_DIR}/gen/generated_protos)
+set(INTERNAL_MODULES ${CMAKE_CURRENT_LIST_DIR}/internal_modules)
+set(NANO_PB_FOLDER ${CMAKE_CURRENT_LIST_DIR}/deps/nanopb)
+
+add_library(nanopb STATIC
+    ${NANO_PB_FOLDER}/pb_common.c
+    ${NANO_PB_FOLDER}/pb_decode.c
+    ${NANO_PB_FOLDER}/pb_encode.c
+)
+
+target_include_directories(nanopb PUBLIC
+    ${NANO_PB_FOLDER}
+)
+
+target_compile_options(nanopb PRIVATE
+    -DPB_ENABLE_MALLOC=1
+)
+
+add_library(wpc_proto STATIC
+    ${CMAKE_CURRENT_LIST_DIR}/wpc_proto.c
+    ${INTERNAL_MODULES}/common.c
+    ${INTERNAL_MODULES}/proto_data.c
+    ${INTERNAL_MODULES}/proto_config.c
+    ${INTERNAL_MODULES}/proto_otap.c
+    ${GENERATED_PROTOS_FOLDER}/config_message.pb.c
+    ${GENERATED_PROTOS_FOLDER}/data_message.pb.c
+    ${GENERATED_PROTOS_FOLDER}/generic_message.pb.c
+    ${GENERATED_PROTOS_FOLDER}/otap_message.pb.c
+    ${GENERATED_PROTOS_FOLDER}/wp_global.pb.c
+)
+
+# TODO the following warnings should be checked
+target_compile_options(wpc_proto PRIVATE
+    -Wno-stringop-truncation
+    -Wno-implicit-fallthrough
+)
+
+target_link_libraries(wpc_proto
+    nanopb
+)
+
+target_include_directories(wpc_proto PUBLIC
+    ${PROJECT_SOURCE_DIR}/api
+)
+
+target_include_directories(wpc_proto PRIVATE
+    ${PROJECT_SOURCE_DIR}/platform
+    ${PROJECT_SOURCE_DIR}/wpc/include
+    ${INTERNAL_MODULES}
+    ${GENERATED_PROTOS_FOLDER}
+)
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.18)
+
+project(meshAPItest LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_BUILD_TYPE RelWithDebInfo)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+add_compile_options(-Wall -Werror -Wextra)
+
+set(WPC_LIB_DIR "${CMAKE_CURRENT_LIST_DIR}/../lib/")
+
+include(FetchContent)
+FetchContent_Declare(
+    wpc-lib
+    SOURCE_DIR ${WPC_LIB_DIR}
+)
+set(BUILD_GMOCK OFF)
+FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG        v1.17.0
+)
+FetchContent_MakeAvailable(wpc-lib googletest)
+
+enable_testing()
+
+add_executable(${CMAKE_PROJECT_NAME}
+    ${CMAKE_CURRENT_LIST_DIR}/test_main.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/wpc_test.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/general_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/scratchpad_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/callback_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/cdd_tests.cpp
+)
+
+target_link_libraries(${CMAKE_PROJECT_NAME}
+    GTest::gtest
+    wpc
+)
+
+include(GoogleTest)
+gtest_discover_tests(${CMAKE_PROJECT_NAME})
+

--- a/test/callback_tests.cpp
+++ b/test/callback_tests.cpp
@@ -166,7 +166,7 @@ protected:
         scan_neighbors_cb.status = status;
     }
 
-    static void onAppConfigDataReceived(uint8_t seq, uint16_t interval, uint8_t* config)
+    static void onAppConfigDataReceived(uint8_t /* seq */, uint16_t interval, uint8_t* config)
     {
         std::lock_guard<std::mutex> lock(app_config_cb.mutex);
         app_config_cb.callback_called = true;
@@ -175,7 +175,7 @@ protected:
         std::memcpy(app_config_cb.config, config, app_config_cb.app_config_size);
     }
 
-    static void onDataSent(uint16_t pduid, uint32_t buffering_delay, uint8_t result)
+    static void onDataSent(uint16_t pduid, uint32_t /* buffering_delay */, uint8_t result)
     {
         std::lock_guard<std::mutex> lock(data_sent_cb.mutex);
         data_sent_cb.callback_called = true;
@@ -191,9 +191,9 @@ protected:
                                app_qos_e qos,
                                uint8_t src_ep,
                                uint8_t dst_ep,
-                               uint32_t travel_time,
-                               uint8_t hop_count,
-                               unsigned long long timestamp_ms_epoch)
+                               uint32_t /* travel_time */,
+                               uint8_t /* hop_count */,
+                               unsigned long long /* timestamp_ms_epoch */)
     {
         if (src_ep != data_received_cb.expected_src_ep || dst_ep != data_received_cb.expected_dst_ep) {
             return false;


### PR DESCRIPTION
c-mes-api can be included to existing cmake projects as a library via FetchContent. example/CMakeLists.txt and example/linux/gw-example/CMakeLists.txt can be used as examples for using "wpc" and "wpc_proto" libraries.

It is also possible to fetch the libraries from git:
```
FetchContent_Declare(
  wpc-lib
  GIT_REPOSITORY https://github.com/wirepas/c-mesh-api/
  GIT_TAG master
  SOURCE_SUBDIR lib
)
```

Existing makefiles are not removed for backwards compatibility, but they can be deprecated and removed in the future.