### PR TITLE
Fix convert_error_code macro

### DIFF
--- a/lib/wpc/wpc.c
+++ b/lib/wpc/wpc.c
@@ -22,14 +22,15 @@
  *          Dual mcu return code are not harmonized so
  *          a different LUT must be used per fonction
  */
-#define convert_error_code(LUT, error)                  \
-    ({                                                  \
-        app_res_e ret = APP_RES_INTERNAL_ERROR;         \
-        if (error >= 0 && (size_t) error < sizeof(LUT)) \
-        {                                               \
-            ret = LUT[error];                           \
-        }                                               \
-        ret;                                            \
+#define convert_error_code(LUT, error)                        \
+    ({                                                        \
+        const size_t lut_size = sizeof(LUT) / sizeof(LUT[0]); \
+        app_res_e ret = APP_RES_INTERNAL_ERROR;               \
+        if (error >= 0 && (size_t) error < lut_size)          \
+        {                                                     \
+            ret = LUT[error];                                 \
+        }                                                     \
+        ret;                                                  \
     })
 
 #define DEFAULT_TIMEOUT_AFTER_STOP_STACK_S 60


### PR DESCRIPTION
Macro was returning invalid values if error code was larger than the number of elements in the lookup table. This was due to an error during calculation of number of elements of the table.

This partially fixes the problem with gateway returning OK status if the sink doesn't support setting CDC items. The sink was returning error code 5 ("not supported"), which is outside of the CDC_ITEM_SET_ERROR_CODE_LUT array. Correct mapping for that case can be done later.